### PR TITLE
Bug fix for open history file

### DIFF
--- a/pcsliner/seter.go
+++ b/pcsliner/seter.go
@@ -33,7 +33,7 @@ func (pl *PCSLiner) SetHistory(filePath string) (err error) {
 		return fmt.Errorf("history file not set")
 	}
 
-	pl.Config.historyFile, err = os.Open(filePath)
+	pl.Config.historyFile, err = os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
如果`pcs_command_history.txt`文件不存在，则创建该文件，否则方向键无法调用历史命令。

Fixes #53 