### PR TITLE
:see_no_evil: 忽略 GoLand 工程配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ captcha.png
 pcs_config.json
 test/
 download/
+
+# GoLand
+.idea/


### PR DESCRIPTION
另外，在 GoLand 里面构建的时候会报错，完整输出如下：

```
GOROOT=D:\Go #gosetup
GOPATH=D:\GoGoGo #gosetup
D:\Go\bin\go.exe build -i -o C:\Windows\Temp\___go_build_main_go.exe D:/GoGoGo/src/github.com/iikira/BaiduPCS-Go/main.go #gosetup
# command-line-arguments
.\main.go:903:19: undefined: cryptoDescription
.\main.go:943:19: undefined: cryptoDescription

Compilation finished with exit code 2
```

就是指定 main.go 入口编译的时候会报错：

```
C:\Users\Administrator>go build -i D:\GoGoGo\src\github.com\iikira\BaiduPCS-Go\main.go
# command-line-arguments
D:\GoGoGo\src\github.com\iikira\BaiduPCS-Go\main.go:903:19: undefined: cryptoDescription
D:\GoGoGo\src\github.com\iikira\BaiduPCS-Go\main.go:943:19: undefined: cryptoDescription
```

在项目目录下直接用 `go build` 没问题，请考虑稍微调整一下 template.go 的位置 😀 