### PR TITLE
增加从分享链接转存及常见秒传链接转存

### DIFF
--- a/baidupcs/baidupcs.go
+++ b/baidupcs/baidupcs.go
@@ -3,15 +3,16 @@ package baidupcs
 
 import (
 	"errors"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strconv"
+
 	"github.com/iikira/BaiduPCS-Go/baidupcs/expires/cachemap"
 	"github.com/iikira/BaiduPCS-Go/baidupcs/internal/panhome"
 	"github.com/iikira/BaiduPCS-Go/baidupcs/pcserror"
 	"github.com/iikira/BaiduPCS-Go/pcsverbose"
 	"github.com/iikira/BaiduPCS-Go/requester"
-	"net/http"
-	"net/http/cookiejar"
-	"net/url"
-	"strconv"
 )
 
 const (
@@ -75,6 +76,10 @@ const (
 	OperationShareList = "列出分享列表"
 	// OperationShareSURLInfo 获取分享详细信息
 	OperationShareSURLInfo = "获取分享详细信息"
+	// OperationShareFileSavetoLocal 用分享链接转存到网盘
+	OperationShareFileSavetoLocal = "用分享链接转存到网盘"
+	// OperationRapidLinkSavetoLocal 用秒传链接转存到网盘
+	OperationRapidLinkSavetoLocal = "用秒传链接转存到网盘"
 	// OperationRecycleList 列出回收站文件列表
 	OperationRecycleList = "列出回收站文件列表"
 	// OperationRecycleRestore 还原回收站文件或目录

--- a/baidupcs/transfer.go
+++ b/baidupcs/transfer.go
@@ -1,0 +1,157 @@
+package baidupcs
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+func (pcs *BaiduPCS) GenerateShareQueryURL(subPath string, params map[string]string) *url.URL {
+	shareURL := &url.URL{
+		Scheme: GetHTTPScheme(true),
+		Host:   PanBaiduCom,
+		Path:   "/share/" + subPath,
+	}
+	uv := shareURL.Query()
+	uv.Set("app_id", PanAppID)
+	uv.Set("channel", "chunlei")
+	uv.Set("clienttype", "0")
+	uv.Set("web", "1")
+	for key, value := range params {
+		uv.Set(key, value)
+	}
+
+	shareURL.RawQuery = uv.Encode()
+	return shareURL
+}
+
+func (pcs *BaiduPCS) PostShareQuery(url string, data map[string]string) (res map[string]string) {
+	dataReadCloser, panError := pcs.sendReqReturnReadCloser(reqTypePan, OperationShareFileSavetoLocal, http.MethodPost, url, data, map[string]string{
+		"User-Agent":   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",
+		"Content-Type": "application/x-www-form-urlencoded",
+		"Referer":      "https://pan.baidu.com/disk/home",
+	})
+	res = make(map[string]string)
+	if panError != nil {
+		res["ErrMsg"] = "提交分享项查询请求时发生错误"
+		return
+	}
+	defer dataReadCloser.Close()
+	body, _ := ioutil.ReadAll(dataReadCloser)
+	errno := gjson.Get(string(body), `errno`).String()
+	if errno != "0" {
+		res["ErrMsg"] = "分享码错误"
+		return
+	}
+	res["ErrMsg"] = "0"
+	return
+}
+
+func (pcs *BaiduPCS) AccessSharePage(sharelink string, first bool) (tokens map[string]string) {
+	tokens = make(map[string]string)
+	tokens["ErrMsg"] = "0"
+	headers := make(map[string]string)
+	headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36"
+	headers["Referer"] = "https://pan.baidu.com/disk/home"
+
+	dataReadCloser, panError := pcs.sendReqReturnReadCloser(reqTypePan, OperationShareFileSavetoLocal, http.MethodGet, sharelink, nil, headers)
+
+	if panError != nil {
+		tokens["ErrMsg"] = "访问分享页失败"
+		return
+	}
+	defer dataReadCloser.Close()
+	body, _ := ioutil.ReadAll(dataReadCloser)
+	not_found_flag := strings.Contains(string(body), "platform-non-found")
+	error_page_title := strings.Contains(string(body), "error-404")
+	if error_page_title {
+		tokens["ErrMsg"] = "页面不存在"
+		return
+	}
+	if not_found_flag {
+		tokens["ErrMsg"] = "分享链接已失效"
+		return
+	} else {
+		re, _ := regexp.Compile(`"bdstoken":"([A-Za-z0-9]+)",`)
+		sub := re.FindSubmatch(body)
+		if len(sub) < 2 {
+			tokens["ErrMsg"] = "分享页面解析失败"
+			return
+		}
+		tokens["bdstoken"] = string(sub[1])
+		if first {
+			return
+		}
+		re, _ = regexp.Compile(`"shareid":([0-9]+),`)
+		sub = re.FindSubmatch(body)
+		if len(sub) < 2 && !first {
+			tokens["ErrMsg"] = "缺少提取码"
+			return
+		}
+		tokens["shareid"] = string(sub[1])
+		re, _ = regexp.Compile(`uk=([0-9]+)`)
+		sub = re.FindSubmatch(body)
+		tokens["uk"] = string(sub[1])
+		return
+
+	}
+
+}
+
+func (pcs *BaiduPCS) GenerateRequestQuery(mode, link string, params map[string]string) (res map[string]string) {
+	res = make(map[string]string)
+	headers := map[string]string{
+		"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.100 Safari/537.36",
+		"Referer":    "https://pan.baidu.com/disk/home",
+	}
+	if mode == "POST" {
+		headers["Content-Type"] = "application/x-www-form-urlencoded"
+	}
+	dataReadCloser, panError := pcs.sendReqReturnReadCloser(reqTypePan, OperationShareFileSavetoLocal, mode, link, params, headers)
+	if panError != nil {
+		res["ErrMsg"] = "未知错误"
+		return
+	}
+	defer dataReadCloser.Close()
+	body, err := ioutil.ReadAll(dataReadCloser)
+
+	if err != nil {
+		res["ErrMsg"] = "未知错误"
+		return
+	}
+	if !gjson.Valid(string(body)) {
+		res["ErrMsg"] = "返回值json解析错误"
+		return
+	}
+	errno := gjson.Get(string(body), `errno`).Int()
+	if errno != 0 {
+		res["ErrMsg"] = "获取分享项元数据错误"
+		if mode == "POST" && errno == 12 {
+			path := gjson.Get(string(body), `info.0.path`).String()
+			_, file := filepath.Split(path)
+			res["ErrMsg"] = fmt.Sprintf("当前目录下已有%s同名文件/文件夹", file)
+		}
+		return
+	}
+	if mode != "POST" {
+		res["title"] = gjson.Get(string(body), `title`).String()
+		res["filename"] = gjson.Get(string(body), `list.0.server_filename`).String()
+		var fids_str string = "["
+		fsids := gjson.Get(string(body), `list.#.fs_id`).Array()
+		if len(fsids) > 1 {
+			res["filename"] += "等多个文件"
+		}
+		for _, sid := range fsids {
+			fids_str += sid.String() + ","
+		}
+		res["fs_id"] = fids_str[:len(fids_str)-1] + "]"
+	}
+	res["ErrMsg"] = fmt.Sprintf("%d", errno)
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -24,4 +24,5 @@ require (
 	github.com/urfave/cli v1.21.1-0.20190817182405-23c83030263f
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339
+	github.com/tidwall/gjson v1.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,12 @@ github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJ
 github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/tidwall/gjson v1.6.0 h1:9VEQWz6LLMUsUl6PueE49ir4Ka6CzLymOAZDxpFsTDc=
+github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
+github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.21.1-0.20190817182405-23c83030263f h1:xKDKjIsL76VUyHcA0G4Qe1cIAUB/nrq6Pt8D411bd1g=

--- a/internal/pcscommand/login.go
+++ b/internal/pcscommand/login.go
@@ -3,12 +3,13 @@ package pcscommand
 import (
 	"bytes"
 	"fmt"
-	"github.com/iikira/Baidu-Login"
+	"image/png"
+	"io/ioutil"
+
+	baidulogin "github.com/iikira/Baidu-Login"
 	"github.com/iikira/BaiduPCS-Go/internal/pcsfunctions/pcscaptcha"
 	"github.com/iikira/BaiduPCS-Go/pcsliner"
 	"github.com/iikira/BaiduPCS-Go/requester"
-	"image/png"
-	"io/ioutil"
 )
 
 // handleVerifyImg 处理验证码, 下载到本地
@@ -29,7 +30,7 @@ func handleVerifyImg(imgURL string) (savePath string, err error) {
 }
 
 // RunLogin 登录百度帐号
-func RunLogin(username, password string) (bduss, ptoken, stoken string, err error) {
+func RunLogin(username, password string) (bduss, ptoken, stoken string, cookies string, err error) {
 	line := pcsliner.NewLiner()
 	defer line.Close()
 
@@ -64,7 +65,7 @@ for_1:
 
 		switch lj.ErrInfo.No {
 		case "0": // 登录成功, 退出循环
-			return lj.Data.BDUSS, lj.Data.PToken, lj.Data.SToken, nil
+			return lj.Data.BDUSS, lj.Data.PToken, lj.Data.SToken, lj.Data.CookieString, nil
 		case "400023", "400101": // 需要验证手机或邮箱
 			fmt.Printf("\n需要验证手机或邮箱才能登录\n选择一种验证方式\n")
 			fmt.Printf("1: 手机: %s\n", lj.Data.Phone)
@@ -109,7 +110,7 @@ for_1:
 					continue
 				}
 				// 登录成功
-				return nlj.Data.BDUSS, nlj.Data.PToken, nlj.Data.SToken, nil
+				return nlj.Data.BDUSS, nlj.Data.PToken, nlj.Data.SToken, lj.Data.CookieString, nil
 			}
 			break for_1
 		case "500001", "500002": // 验证码

--- a/internal/pcscommand/transfer.go
+++ b/internal/pcscommand/transfer.go
@@ -1,0 +1,132 @@
+package pcscommand
+
+import (
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/iikira/BaiduPCS-Go/baidupcs"
+)
+
+// RunShareTransfer 执行分享链接转存到网盘
+func RunShareTransfer(params []string) {
+	var link string
+	var extracode string
+	if len(params) == 1 {
+		link = params[0]
+		if strings.Contains(link, "bdlink=") || !strings.Contains(link, "pan.baidu.com/") {
+			RunRapidTransfer(link)
+			return
+		}
+		extracode = "none"
+	} else if len(params) == 2 {
+		link = params[0]
+		extracode = params[1]
+	}
+	if link[len(link)-1:len(link)] == "/" {
+		link = link[0 : len(link)-1]
+	}
+	featurestrs := strings.Split(link, "/")
+	featurestr := featurestrs[len(featurestrs)-1]
+	if strings.Contains(featurestr, "init?") {
+		featurestr = "1" + strings.Split(featurestr, "=")[1]
+	}
+	if len(featurestr) != 23 || featurestr[0:1] != "1" || len(extracode) != 4 {
+		fmt.Printf("%s失败: %s\n", baidupcs.OperationShareFileSavetoLocal, "链接地址或提取码非法")
+		return
+	}
+	// link = "pan.baidu.com/share/init?surl=" + featurestr[1:]
+	link = "pan.baidu.com/s/" + featurestr
+	pcs := GetBaiduPCS()
+	tokens := pcs.AccessSharePage("https://"+link, true)
+	if tokens["ErrMsg"] != "0" {
+		fmt.Printf("%s失败: %s\n", baidupcs.OperationShareFileSavetoLocal, tokens["ErrMsg"])
+		return
+	}
+	var vefiryurl string
+	featuremap := make(map[string]string)
+	featuremap["surl"] = featurestr[1:]
+	featuremap["bdstoken"] = tokens["bdstoken"]
+	if extracode != "none" {
+
+		vefiryurl = pcs.GenerateShareQueryURL("verify", featuremap).String()
+		res := pcs.PostShareQuery(vefiryurl, map[string]string{
+			"pwd": extracode,
+		})
+		if res["ErrMsg"] != "0" {
+			fmt.Printf("%s失败: %s\n", baidupcs.OperationShareFileSavetoLocal, res["ErrMsg"])
+			return
+		}
+	}
+
+	tokens = pcs.AccessSharePage("https://pan.baidu.com/s/"+featurestr, false)
+	if tokens["ErrMsg"] != "0" {
+		fmt.Printf("%s失败: %s\n", baidupcs.OperationShareFileSavetoLocal, tokens["ErrMsg"])
+		return
+	}
+	bdstoken := tokens["bdstoken"]
+	delete(tokens, "bdstoken")
+	tokens["desc"] = "1"
+	tokens["num"] = "100"
+	tokens["order"] = "time"
+	tokens["page"] = "1"
+	tokens["root"] = "1"
+	tokens["showempty"] = "0"
+	listurl := pcs.GenerateShareQueryURL("list", tokens).String()
+	emptymap := make(map[string]string)
+	metas := pcs.GenerateRequestQuery("GET", listurl, nil)
+	if metas["ErrMsg"] != "0" {
+		fmt.Printf("%s失败: %s\n", baidupcs.OperationShareFileSavetoLocal, metas["ErrMsg"])
+		return
+	}
+	emptymap["bdstoken"] = bdstoken
+	emptymap["from"] = tokens["uk"]
+	emptymap["shareid"] = tokens["shareid"]
+	transferurl := pcs.GenerateShareQueryURL("transfer", emptymap).String()
+	postdata := make(map[string]string)
+	postdata["fsidlist"] = metas["fs_id"]
+	postdata["path"] = GetActiveUser().Workdir
+	resp := pcs.GenerateRequestQuery("POST", transferurl, postdata)
+	if resp["ErrMsg"] != "0" {
+		fmt.Printf("%s失败: %s\n", baidupcs.OperationShareFileSavetoLocal, resp["ErrMsg"])
+		return
+	}
+
+	fmt.Printf("%s成功, 保存了%s到当前目录\n", baidupcs.OperationShareFileSavetoLocal, metas["filename"])
+}
+
+// RunRapidTransfer 执行秒传链接解析及保存
+func RunRapidTransfer(link string) {
+	if strings.Contains(link, "bdlink=") || strings.Contains(link, "bdpan://") {
+		r, _ := regexp.Compile(`(bdlink=|bdpan://)([^\s]+)`)
+		link1 := r.FindStringSubmatch(link)[2]
+		decodeBytes, err := base64.StdEncoding.DecodeString(link1)
+		if err != nil {
+			fmt.Printf("%s失败: %s\n", baidupcs.OperationRapidLinkSavetoLocal, "秒传链接格式错误")
+			return
+		}
+		link = string(decodeBytes)
+	}
+	substrs := strings.Split(link, "#")
+	if len(substrs) == 4 {
+		md5 := substrs[0]
+		slicemd5 := substrs[1]
+		length, _ := strconv.ParseInt(substrs[2], 10, 64)
+		filename := filepath.Join(GetActiveUser().Workdir, substrs[3])
+		RunRapidUpload(filename, md5, slicemd5, "", length)
+		return
+	}
+	substrs = strings.Split(link, "|")
+	if len(substrs) == 4 {
+		md5 := substrs[2]
+		slicemd5 := substrs[3]
+		length, _ := strconv.ParseInt(substrs[1], 10, 64)
+		filename := filepath.Join(GetActiveUser().Workdir, substrs[0])
+		RunRapidUpload(filename, md5, slicemd5, "", length)
+		return
+	}
+	fmt.Printf("%s失败: %s\n", baidupcs.OperationRapidLinkSavetoLocal, "秒传链接格式错误")
+}

--- a/internal/pcsconfig/baidu.go
+++ b/internal/pcsconfig/baidu.go
@@ -3,15 +3,16 @@ package pcsconfig
 import (
 	"errors"
 	"fmt"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
 	"github.com/iikira/BaiduPCS-Go/baidupcs"
 	"github.com/iikira/BaiduPCS-Go/pcstable"
 	"github.com/iikira/BaiduPCS-Go/pcsutil/converter"
 	"github.com/iikira/baidu-tools/tieba"
 	"github.com/olekukonko/tablewriter"
-	"path"
-	"path/filepath"
-	"strconv"
-	"strings"
 )
 
 var (
@@ -33,9 +34,10 @@ type Baidu struct {
 	Sex string  `json:"sex"` // 性别
 	Age float64 `json:"age"` // 帐号年龄
 
-	BDUSS  string `json:"bduss"`
-	PTOKEN string `json:"ptoken"`
-	STOKEN string `json:"stoken"`
+	BDUSS   string `json:"bduss"`
+	PTOKEN  string `json:"ptoken"`
+	STOKEN  string `json:"stoken"`
+	COOKIES string `json:"cookies"`
 
 	Workdir string `json:"workdir"` // 工作目录
 }
@@ -44,6 +46,12 @@ type Baidu struct {
 func (baidu *Baidu) BaiduPCS() *baidupcs.BaiduPCS {
 	pcs := baidupcs.NewPCS(Config.AppID, baidu.BDUSS)
 	pcs.SetStoken(baidu.STOKEN)
+	if strings.Contains(baidu.COOKIES, "BAIDUID=") {
+		// fmt.Println("已加载完整Cookies，可以使用转存功能")
+		pcs = baidupcs.NewPCSWithCookieStr(Config.AppID, baidu.COOKIES)
+	} else if baidu.BDUSS != "" {
+		fmt.Println("注：分享链接转存功能无法使用，可使用-cookies参数重新登录以启用")
+	}
 	pcs.SetHTTPS(Config.EnableHTTPS)
 	pcs.SetPCSUserAgent(Config.PCSUA)
 	pcs.SetPanUserAgent(Config.PanUA)

--- a/internal/pcsconfig/maniper.go
+++ b/internal/pcsconfig/maniper.go
@@ -1,9 +1,11 @@
 package pcsconfig
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/iikira/BaiduPCS-Go/pcsutil/converter"
 	"github.com/iikira/BaiduPCS-Go/requester"
-	"strings"
 )
 
 const (
@@ -112,8 +114,13 @@ func (c *PCSConfig) CheckBaiduUserExist(baidubase *BaiduBase) bool {
 	return err == nil
 }
 
-// SetupUserByBDUSS 设置百度 bduss, ptoken, stoken 并保存
-func (c *PCSConfig) SetupUserByBDUSS(bduss, ptoken, stoken string) (baidu *Baidu, err error) {
+// SetupUserByBDUSS 设置百度 bduss, ptoken, stoken, cookies 并保存
+func (c *PCSConfig) SetupUserByBDUSS(bduss, ptoken, stoken, cookies string) (baidu *Baidu, err error) {
+	if cookies != "" {
+		re, _ := regexp.Compile(`BDUSS=(.+?);`)
+		sub := re.FindSubmatch([]byte(cookies))
+		bduss = string(sub[1])
+	}
 	b, err := NewUserInfoByBDUSS(bduss)
 	if err != nil {
 		return nil, err
@@ -125,6 +132,7 @@ func (c *PCSConfig) SetupUserByBDUSS(bduss, ptoken, stoken string) (baidu *Baidu
 
 	b.PTOKEN = ptoken
 	b.STOKEN = stoken
+	b.COOKIES = cookies
 
 	c.BaiduUserList = append(c.BaiduUserList, b)
 

--- a/main.go
+++ b/main.go
@@ -1366,11 +1366,14 @@ func main() {
 			Before:    reloadFn,
 			Description: `
 			转存文件/目录
-	如果没有提取码，则第二个位置留空；只能转存到当前网盘目录下，不支持旧百度云的短链接
+	如果没有提取码，则第二个位置留空；只能转存到当前网盘目录下，
+	分享链接支持常规百度云链接（不支持旧百度云的短链接）及常见秒传链接（不支持游侠）
 	
-	实例：
-	转存 https://pan.baidu.com/s/1VYzSl7465sdrQXe8GT5RdQ 提取码704e
+	实例 (以下链接均为无效链接)：
 	BaiduPCS-Go transfer pan.baidu.com/s/1VYzSl7465sdrQXe8GT5RdQ 704e
+	BaiduPCS-Go transfer A5AAE70207FFD51AB839D60B39FD0FD5#EE3289A6F0473AC34F83483E80A29B42#8554286#测试.7z
+	BaiduPCS-Go transfer bdpan://xxxxx|yyyyyy|zzzz|oooo
+	BaiduPCS-Go transfer bdlink=MDMzMjkxQzNFNkQ4RDdEMzI2Q
 	`,
 			Action: func(c *cli.Context) error {
 				if c.NArg() < 1 || c.NArg() > 2 {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,16 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
 	"github.com/iikira/BaiduPCS-Go/baidupcs"
 	"github.com/iikira/BaiduPCS-Go/internal/pcscommand"
 	"github.com/iikira/BaiduPCS-Go/internal/pcsconfig"
@@ -22,15 +32,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/peterh/liner"
 	"github.com/urfave/cli"
-	"os"
-	"os/exec"
-	"path"
-	"path/filepath"
-	"runtime"
-	"sort"
-	"strconv"
-	"strings"
-	"unicode"
 )
 
 const (
@@ -153,7 +154,7 @@ func main() {
 				lineArgs                   = args.Parse(line)
 				numArgs                    = len(lineArgs)
 				acceptCompleteFileCommands = []string{
-					"cd", "cp", "download", "export", "fixmd5", "locate", "ls", "meta", "mkdir", "mv", "rapidupload", "rm", "share", "tree", "upload",
+					"cd", "cp", "download", "export", "fixmd5", "locate", "ls", "meta", "mkdir", "mv", "rapidupload", "rm", "share", "transfer", "tree", "upload",
 				}
 				closed = strings.LastIndex(line, " ") == len(line)-1
 			)
@@ -403,25 +404,32 @@ func main() {
 		BaiduPCS-Go login
 		BaiduPCS-Go login -username=liuhua
 		BaiduPCS-Go login -bduss=123456789
+		BaiduPCS-Go login -cookies="BDUSS=xxxxx; BAIDUID=yyyyyy; STOKEN=zzzzz; ...."
 
 	常规登录:
 		按提示一步一步来即可.
 
 	百度BDUSS获取方法:
 		参考这篇 Wiki: https://github.com/iikira/BaiduPCS-Go/wiki/关于-获取百度-BDUSS
-		或者百度搜索: 获取百度BDUSS`,
+		或者百度搜索: 获取百度BDUSS
+		
+	百度Cookies获取办法:
+	以Chrome为例，登录到自己的百度网盘主页，F12，然后切换到Network标签，刷新页面，Network标签下会刷出一大堆东西
+	找到第一条，点击，看到右侧出现的详情，往下翻到Cookies: xxxx; xxxxx; xxx...这样的字段，从冒号后（没有空格）一直复制到字段末尾`,
 			Category: "百度帐号",
 			Before:   reloadFn,
 			After:    saveFunc,
 			Action: func(c *cli.Context) error {
-				var bduss, ptoken, stoken string
-				if c.IsSet("bduss") {
+				var bduss, ptoken, stoken, cookies string
+				if c.IsSet("cookies") {
+					cookies = c.String("cookies")
+				} else if c.IsSet("bduss") {
 					bduss = c.String("bduss")
 					ptoken = c.String("ptoken")
 					stoken = c.String("stoken")
 				} else if c.NArg() == 0 {
 					var err error
-					bduss, ptoken, stoken, err = pcscommand.RunLogin(c.String("username"), c.String("password"))
+					bduss, ptoken, stoken, cookies, err = pcscommand.RunLogin(c.String("username"), c.String("password"))
 					if err != nil {
 						fmt.Println(err)
 						return err
@@ -431,7 +439,7 @@ func main() {
 					return nil
 				}
 
-				baidu, err := pcsconfig.Config.SetupUserByBDUSS(bduss, ptoken, stoken)
+				baidu, err := pcsconfig.Config.SetupUserByBDUSS(bduss, ptoken, stoken, cookies)
 				if err != nil {
 					fmt.Println(err)
 					return nil
@@ -460,6 +468,10 @@ func main() {
 				cli.StringFlag{
 					Name:  "stoken",
 					Usage: "百度 STOKEN, 配合 -bduss 参数使用 (可选)",
+				},
+				cli.StringFlag{
+					Name:  "cookies",
+					Usage: "使用百度 Cookies 来登录百度账号 (以此方式登录可使用分享链接转存功能)",
 				},
 			},
 		},
@@ -1343,6 +1355,29 @@ func main() {
 					fmt.Printf("\n")
 				}
 
+				return nil
+			},
+		},
+		{
+			Name:      "transfer",
+			Usage:     "转存文件/目录",
+			UsageText: app.Name + " transfer <分享链接> <提取码>(如果有)",
+			Category:  "百度网盘",
+			Before:    reloadFn,
+			Description: `
+			转存文件/目录
+	如果没有提取码，则第二个位置留空；只能转存到当前网盘目录下，不支持旧百度云的短链接
+	
+	实例：
+	转存 https://pan.baidu.com/s/1VYzSl7465sdrQXe8GT5RdQ 提取码704e
+	BaiduPCS-Go transfer pan.baidu.com/s/1VYzSl7465sdrQXe8GT5RdQ 704e
+	`,
+			Action: func(c *cli.Context) error {
+				if c.NArg() < 1 || c.NArg() > 2 {
+					cli.ShowCommandHelp(c, c.Command.Name)
+					return nil
+				}
+				pcscommand.RunShareTransfer(c.Args())
 				return nil
 			},
 		},


### PR DESCRIPTION
新增transfer命令，支持传统的分享链接（支持提取码）及秒传链接（梦姬标准格式、Pandownload、插件生成的bdlink=xxxx格式，不支持游侠格式）